### PR TITLE
Remove any line breaks from data sent to server

### DIFF
--- a/ircclient/ircclient.py
+++ b/ircclient/ircclient.py
@@ -64,8 +64,9 @@ class IRCClient:
 	def log_line(self, line):
 		print line
 		self.lines.append(line)
-	
+
 	def send(self, line):
+		line = line.replace('\n', ' ').replace('\r', '')
 		self.log_line(timestamp() + " SENT: " + line)
 
 		self.last_action = datetime.datetime.now()
@@ -99,7 +100,7 @@ class IRCClient:
 
 			a = string[0:split]
 			b = string[split:]
-		
+
 			return self.tell(target, a) + self.tell(target, b)
 		else:
 			return self.send("PRIVMSG " + target + " :" + string)
@@ -128,7 +129,7 @@ class IRCClient:
 				prefix, nick = m[0:2]
 
 				self.temp_nick_list.append(nick)
-			
+
 	def on_end_nick_list(self, tupels):
 		self.nick_lists[self.temp_nick_list_channel] = self.temp_nick_list
 		self.temp_nick_list_channel = None


### PR DESCRIPTION
> IRC protocol does not allow CR and/or LF in its message, except for CRLF at the end.

http://stackoverflow.com/questions/13898584/insert-line-breaks-into-an-irc-message