### PR TITLE
New plugin: degoogle

### DIFF
--- a/creds.txt
+++ b/creds.txt
@@ -16,6 +16,9 @@ pilt:
 plugins/stava
 plugins/tenta
 
+raek:
+plugins/degoogle
+
 teetow:
 plugins/kolli
 plugins/qotd

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -6,4 +6,4 @@ __all__ = ['plugins', 'command_catcher', 'first_plugin', 'auto_join', 'aduno',
             'ical_parser', 'icq', 'pylisp', 'lithcourse', 'scale', 'postnr',
             'tenta', 'prisjakt', 'spotify', 'stava', 'stock', 'down', 'metacritic',
             'notes', 'fml', 'systembolaget', 'randombuy', 'festern_bbq',
-            'compliment', 'roulette', 'tyda', 'yrno', 'tweet', 'calc']
+            'compliment', 'roulette', 'tyda', 'yrno', 'tweet', 'calc', 'degoogle']

--- a/plugins/degoogle.py
+++ b/plugins/degoogle.py
@@ -1,0 +1,41 @@
+# coding: utf-8
+
+import re
+import urlparse
+
+from commands import Command
+
+
+def _find_google_result_url(message):
+    m = re.search(r'https?://([^/]*\.)?[Gg][Oo][Oo][Gg][Ll][Ee]\.[^/]+/url\S+', message)
+    if not m:
+        return None
+    url = m.group(0)
+    query_string = urlparse.urlsplit(url).query
+    query_dict = urlparse.parse_qs(query_string)
+    if "url" in query_dict:
+        return query_dict["url"][0]
+    else:
+        return None
+
+
+class DegooglePlugin(Command):
+    def __init__(self):
+        self._last_url = None
+
+    def on_privmsg(self, bot, source, target, message):
+        url = _find_google_result_url(message)
+        if url:
+            self._last_url = url
+
+    def trig_degoogle(self, bot, source, target, trigger, argument):
+        if argument:
+            url = _find_google_result_url(argument)
+            if not url:
+                bot.tell(target, "The argument was not a Google result URL.")
+            else:
+                bot.tell(target, "de-Googled: " + url)
+        elif self._last_url:
+            bot.tell(target, "de-Googled: " + self._last_url)
+        else:
+            bot.tell(target, "Did not find any Google result URL.")

--- a/plugins/degoogle.py
+++ b/plugins/degoogle.py
@@ -32,10 +32,10 @@ class DegooglePlugin(Command):
         if argument:
             url = _find_google_result_url(argument)
             if not url:
-                bot.tell(target, "The argument was not a Google result URL.")
+                return "The argument was not a Google result URL."
             else:
-                bot.tell(target, "de-Googled: " + url)
+                return "de-Googled: " + url
         elif self._last_url:
-            bot.tell(target, "de-Googled: " + self._last_url)
+            return "de-Googled: " + self._last_url
         else:
-            bot.tell(target, "Did not find any Google result URL.")
+            return "Did not find any Google result URL."


### PR DESCRIPTION
The purpose of this plugin is to extract the target URL of Google result link. If a user posts a link copied from Google in a channel, you can run the `.degoogle` command do "degoogle" the last posted link:

    <raek> ZOMG, typinferens!!! http://www.google.se/url?sa=t&rct=j&q=&esrc=s&source=web&cd=1&cad=rja&uact=8&ved=0CCEQFjAAahUKEwil0eP444rGAhWBjCwKHb4iAJ4&url=http%3A%2F%2Fciteseerx.ist.psu.edu%2Fviewdoc%2Fdownload%3Fdoi%3D10.1.1.65.7733%26rep%3Drep1%26type%3Dpdf&ei=VCR7VaXXGIGZsgG-xYDwCQ&usg=AFQjCNEZd7yLYNia8S_uC0CF-s0v5PHQ7A&sig2=rOx-Me30SoVfg9zhGdCADg&bvm=bv.95515949,d.bGg
    <not-raek> .degoogle
    <pynik> http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.65.7733&rep=rep1&type=pdf

And everyone is happy. Yay. The `.degoogle` command can also be given a URL as an argument.
