### PR TITLE
Add support for 'flet' and 'labels' in pylisp

### DIFF
--- a/plugins/pylisp.py
+++ b/plugins/pylisp.py
@@ -272,6 +272,25 @@ class ConsCell:
 
 			return code.eval(child_env)
 
+		if isinstance(first, Symbol) and first.name in ["flet", "labels"]:
+			bindings = rest.first()
+			code = ExpressionBody(rest.rest())
+
+			child_env = Environment(env)
+
+			for binding in bindings:
+				symbol = binding.first()
+				parameters = binding.rest().first()
+				expression = binding.rest().rest()
+				if first.name == "flet":
+					value = Lambda(env, parameters, expression)
+				else:
+					value = Lambda(child_env, parameters, expression)
+
+				setq_func(child_env, symbol, value)
+
+			return code.eval(child_env)
+
 		if isinstance(first, Symbol) and first.name == "setq":
 			return setq_func(env, rest.first(), rest.rest().first().eval(env))
 


### PR DESCRIPTION
This commit adds the two new special forms FLET and LABELS which behave like in Common Lisp. Their syntaxes are like this:

    (flet ((increment (n) (+ n 1)
           (double (n) (* n 2)))
      (double (increment 5)))
    => 12

    (labels ((double-fact (n) (* 2 (fact n)))
             (fact (n) (if (= n 0) 1 (* n (fact (- n 1))))))
      (double-fact 5))
    => 240

In the FLET special form, the bound functions cannot refer to themselves or to each other. In the LABELS special form the functions can call themselves and each other.